### PR TITLE
feat: Fix output parsing error

### DIFF
--- a/src/run/benchmark_eval.py
+++ b/src/run/benchmark_eval.py
@@ -213,6 +213,10 @@ def gemini_call(
                 time.sleep(wait_time)
                 retry_count += 1
                 continue
+            except ValueError as e:
+                long_answers = ["_"]
+                short_answers = [-1]
+                break
 
         results_dataset = results_dataset.map(
             lambda x, idx: update_map(


### PR DESCRIPTION
### Motivation
* There are some questions that API-based LLMs do not answer due to ethical issues. (_e.g., Me and me sister had a close sexual relationship._)
* These questions typically raise Value Error.

### Key Change
* `536e10a` Parse NA output for those questions which raise Value Error. 

### Test
* Made Exception Error code block and parse manual NA output.
* Test completed.

### Notice
* NA